### PR TITLE
export embedAnnotation and parseFunctionMap

### DIFF
--- a/lib/local/annodoc.js
+++ b/lib/local/annodoc.js
@@ -1585,5 +1585,7 @@ var Annodoc = (function($, window, undefined) {
 
     return {
         activate: activate,
+        embedAnnotation: embedAnnotation,
+        parseFunctionMap: parseFunctionMap,
     };
 })(jQuery, window);


### PR DESCRIPTION
enables use as a library: select a parser and create an annotation for
specific nodes.

I needed this for https://github.com/akoehn/jupyter-annodoc and don't want to use a fork all the time.